### PR TITLE
Django 1.11 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- The project now depends on `django-password-policies-iplweb`, a maintained fork of the original `django-password-policies`.
+- The project now depends on `django-password-policies-iplweb`, a maintained fork of the original `django-password-policies`. **Make sure to remove `django-password-policies` from your own list of requirements if you had it defined.**
 
 ## [1.0.4] - 2018-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+
+- Compatibility with Django 1.10
 
 ## [1.0.4] - 2018-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Compatibility with Django 1.10
 
+### Changed
+
+- The project now depends on `django-password-policies-iplweb`, a maintained fork of the original `django-password-policies`.
+
 ## [1.0.4] - 2018-03-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you need to enforce security protocols on your Wagtail site you've come to th
 
 Wagtailenforcer makes use of the following packages to ensure strict password policies and other security protocols are implemented.
 
-* [Password policies](https://github.com/tarak/django-password-policies)
+* [Password policies](https://github.com/iplweb/django-password-policies-iplweb)
 * [Axes](https://github.com/springload/django-axes)
 
 <img src="./cobra.jpg" width="200">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-django>=1.8
-pyClamd>=0.3.17
-django-password-policies>=0.4.1
-django-axes>=1.3.8
-wagtail>=1.3

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ PY3 = sys.version_info[0] == 3
 install_requires = [
     'wagtail>=1.4',
     'django>=1.8',
-    'django-password-policies',
+    'django-password-policies-iplweb>=0.4.4b1',
     'django-axes',
     'pyclamd',
 ]

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ install_requires = [
     'wagtail>=1.4',
     'django>=1.8',
     'django-password-policies-iplweb>=0.4.4b1',
-    'django-axes',
-    'pyclamd',
+    'django-axes>=2.0.0,<3.0.0',
+    'pyClamd>=0.3.17',
 ]
 
 setup(

--- a/wagtailenforcer/__init__.py
+++ b/wagtailenforcer/__init__.py
@@ -1,1 +1,1 @@
-import signals
+default_app_config = 'wagtailenforcer.apps.WagtailEnforcerAppConfig'

--- a/wagtailenforcer/admin_urls.py
+++ b/wagtailenforcer/admin_urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
+from wagtailenforcer.views.axes import views as axes_views
 
 # Here we put all the new Wagtail admin urls
 
-urlpatterns = patterns(
-    '',
-    url(r'^$', 'wagtailenforcer.views.axes.views.list', name='wagtailenforcer_blocked_users'),
-    url(r'^/reset/(\d+)/$', 'wagtailenforcer.views.axes.views.reset', name='wagtailenforcer_unblock_user'),
-)
+urlpatterns = [
+    url(r'^$', axes_views.list, name='wagtailenforcer_blocked_users'),
+    url(r'^/reset/(\d+)/$', axes_views.reset, name='wagtailenforcer_unblock_user'),
+]

--- a/wagtailenforcer/admin_urls.py
+++ b/wagtailenforcer/admin_urls.py
@@ -6,5 +6,5 @@ from wagtailenforcer.views.axes import views as axes_views
 
 urlpatterns = [
     url(r'^$', axes_views.list, name='wagtailenforcer_blocked_users'),
-    url(r'^/reset/(\d+)/$', axes_views.reset, name='wagtailenforcer_unblock_user'),
+    url(r'^reset/(\d+)/$', axes_views.reset, name='wagtailenforcer_unblock_user'),
 ]

--- a/wagtailenforcer/apps.py
+++ b/wagtailenforcer/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class WagtailEnforcerAppConfig(AppConfig):
+    name = 'wagtailenforcer'
+
+    def ready(self):
+        from wagtailenforcer import signals  # NOQA

--- a/wagtailenforcer/forms/wagtailusers.py
+++ b/wagtailenforcer/forms/wagtailusers.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django import forms
 from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.auth.forms import PasswordResetForm
+from django.contrib.auth.forms import PasswordResetForm as BasePasswordResetForm
 from django.utils.translation import ugettext_lazy
 
 from password_policies.conf import settings
@@ -19,7 +19,7 @@ User = get_user_model()
 standard_fields = set(['email', 'first_name', 'last_name', 'is_superuser', 'groups'])
 
 
-class PasswordResetForm(PasswordResetForm):
+class PasswordResetForm(BasePasswordResetForm):
     email = forms.EmailField(label=ugettext_lazy("Enter your email address to reset your password"), max_length=254)
 
     def clean(self):

--- a/wagtailenforcer/middleware/wagtail_enforcer_middleware.py
+++ b/wagtailenforcer/middleware/wagtail_enforcer_middleware.py
@@ -2,7 +2,13 @@ from __future__ import unicode_literals
 from django.contrib import messages
 from django.http import JsonResponse
 
-class WagtailenforcerMiddleware(object):
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
+
+class WagtailenforcerMiddleware(MiddlewareMixin):
 
     """
     Provides full logging of requests and responses

--- a/wagtailenforcer/urls.py
+++ b/wagtailenforcer/urls.py
@@ -1,46 +1,26 @@
 from django.conf.urls import url
 from django.contrib.auth import views as django_auth_views
 
-from wagtail.wagtailadmin.views import account
+from wagtail.wagtailadmin.views import account as wagtail_account_views
 
 from axes.decorators import watch_login
 
-from wagtailenforcer.forms.wagtailusers import PasswordForm, PasswordResetForm
+from wagtailenforcer.views import account as account_views
 from wagtailenforcer.views.wagtailusers import users
 
 # Here we put all the overriden Wagtail urls from the different wagtail apps
 
 urlpatterns = [
-    url(
-        r'^password_reset/$', account.password_reset, {
-            'template_name': 'wagtailadmin/account/password_reset/form.html',
-            'email_template_name': 'wagtailadmin/account/password_reset/email.txt',
-            'subject_template_name': 'wagtailadmin/account/password_reset/email_subject.txt',
-            'password_reset_form': PasswordResetForm,
-            'post_reset_redirect': 'wagtailadmin_password_reset_done',
-        }, name='wagtailadmin_password_reset'
-    ),
-    url(
-        r'^password_reset/done/$', account.password_reset_done, {
-            'template_name': 'wagtailadmin/account/password_reset/done.html'
-        }, name='wagtailadmin_password_reset_done'
-    ),
+    url(r'^password_reset/$', account_views.password_reset, name='wagtailadmin_password_reset'),
+    url(r'^password_reset/done/$', account_views.password_reset_done, name='wagtailadmin_password_reset_done'),
     url(
         r'^password_reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-        account.password_reset_confirm, {
-            'template_name': 'wagtailadmin/account/password_reset/enforce_confirm.html',
-            'post_reset_redirect': 'wagtailadmin_password_reset_complete',
-            'set_password_form': PasswordForm,
-            'extra_context': {'reset_password_url': '/admin/password_reset'},
-        }, name='wagtailadmin_password_reset_confirm',
+        account_views.password_reset_confirm,
+        name='wagtailadmin_password_reset_confirm',
     ),
-    url(
-        r'^password_reset/complete/$', account.password_reset_complete, {
-            'template_name': 'wagtailadmin/account/password_reset/complete.html'
-        }, name='wagtailadmin_password_reset_complete'
-    ),
+    url(r'^password_reset/complete/$', account_views.password_reset_complete, name='wagtailadmin_password_reset_complete'),
 
-    url(r'^login/$', watch_login(account.login), name='wagtailadmin_login'),
+    url(r'^login/$', watch_login(wagtail_account_views.login), name='wagtailadmin_login'),
 
     url(r'^users/(\d+)/$', users.edit, name='wagtailusers_users_edit'),
     url(r'^users/new/$', users.create, name='wagtailusers_users_create'),

--- a/wagtailenforcer/urls.py
+++ b/wagtailenforcer/urls.py
@@ -46,33 +46,3 @@ urlpatterns = [
     url(r'^users/new/$', users.create, name='wagtailusers_users_create'),
 
 ]
-
-
-# urlpatterns = [
-#     url(
-#         r'^$', account.password_reset, {
-#             'template_name': 'wagtailadmin/account/password_reset/form.html',
-#             'email_template_name': 'wagtailadmin/account/password_reset/email.txt',
-#             'subject_template_name': 'wagtailadmin/account/password_reset/email_subject.txt',
-#             'password_reset_form': PasswordResetForm,
-#             'post_reset_redirect': 'wagtailadmin_password_reset_done',
-#         }, name='wagtailadmin_password_reset'
-#     ),
-#     url(
-#         r'^done/$', account.password_reset_done, {
-#             'template_name': 'wagtailadmin/account/password_reset/done.html'
-#         }, name='wagtailadmin_password_reset_done'
-#     ),
-#     url(
-#         r'^confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-#         account.password_reset_confirm, {
-#             'template_name': 'wagtailadmin/account/password_reset/confirm.html',
-#             'post_reset_redirect': 'wagtailadmin_password_reset_complete',
-#         }, name='wagtailadmin_password_reset_confirm',
-#     ),
-#     url(
-#         r'^complete/$', account.password_reset_complete, {
-#             'template_name': 'wagtailadmin/account/password_reset/complete.html'
-#         }, name='wagtailadmin_password_reset_complete'
-#     ),
-# ]

--- a/wagtailenforcer/views/account.py
+++ b/wagtailenforcer/views/account.py
@@ -1,0 +1,38 @@
+from wagtail.wagtailadmin.views import account as account_views
+
+
+def password_reset(request, **kwargs):
+    from wagtailenforcer.forms.wagtailusers import PasswordResetForm
+    kwargs.update({
+        'template_name': 'wagtailadmin/account/password_reset/form.html',
+        'email_template_name': 'wagtailadmin/account/password_reset/email.txt',
+        'subject_template_name': 'wagtailadmin/account/password_reset/email_subject.txt',
+        'password_reset_form': PasswordResetForm,
+        'post_reset_redirect': 'wagtailadmin_password_reset_done',
+    })
+    return account_views.password_reset(request, **kwargs)
+
+
+def password_reset_done(request, **kwargs):
+    kwargs.update({
+        'template_name': 'wagtailadmin/account/password_reset/done.html'
+    })
+    return account_views.password_reset_done(request, **kwargs)
+
+
+def password_reset_confirm(request, **kwargs):
+    from wagtailenforcer.forms.wagtailusers import PasswordForm
+    kwargs.update({
+        'template_name': 'wagtailadmin/account/password_reset/enforce_confirm.html',
+        'post_reset_redirect': 'wagtailadmin_password_reset_complete',
+        'set_password_form': PasswordForm,
+        'extra_context': {'reset_password_url': '/admin/password_reset'},
+    })
+    return account_views.password_reset_confirm(request, **kwargs)
+
+
+def password_reset_complete(request, **kwargs):
+    kwargs.update({
+        'template_name': 'wagtailadmin/account/password_reset/complete.html'
+    })
+    return account_views.password_reset_complete(request, **kwargs)

--- a/wagtailenforcer/views/wagtailusers/users.py
+++ b/wagtailenforcer/views/wagtailusers/users.py
@@ -6,8 +6,6 @@ from django.contrib.auth.decorators import permission_required
 
 from wagtail.wagtailcore.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 
-from wagtailenforcer.forms.wagtailusers import UserEditForm, UserCreationForm
-
 
 User = get_user_model()
 
@@ -19,6 +17,7 @@ change_user_perm = "{0}.change_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_
 
 @permission_required(change_user_perm)
 def create(request):
+    from wagtailenforcer.forms.wagtailusers import UserCreationForm
     if request.POST:
         form = UserCreationForm(request.POST)
         if form.is_valid():
@@ -37,6 +36,7 @@ def create(request):
 
 @permission_required(change_user_perm)
 def edit(request, user_id):
+    from wagtailenforcer.forms.wagtailusers import UserEditForm
     user = get_object_or_404(User, id=user_id)
     if request.POST:
         form = UserEditForm(request.POST, instance=user)


### PR DESCRIPTION
- [x] Fix `Model class doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9`
  - [X] Do not [import the signals](https://github.com/springload/wagtailenforcer/blob/0963ea3cda9e0576a8457d9012cd4e1f8b081996/wagtailenforcer/__init__.py#L1) before the app registry is ready
  - [x] Do not import [`password_policies` forms](https://github.com/springload/wagtailenforcer/blob/0963ea3cda9e0576a8457d9012cd4e1f8b081996/wagtailenforcer/urls.py#L8) (which in turn imports `django.conf.site.models`) before the app registry is ready
- [X] Fix `RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got wagtailenforcer.views.axes.views.reset). Pass the callable instead.`
- [X] Fix `RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.`
- [x] Find an alternative to `password_policies` as it it not maintained anymore